### PR TITLE
fixed the classifier adaptation reference

### DIFF
--- a/auditory_aphasia/acquisition/acquisition_interface.py
+++ b/auditory_aphasia/acquisition/acquisition_interface.py
@@ -136,7 +136,7 @@ def init_acquisition(
         filter_order=classifier_config.filter_order,
         ivals=classifier_config.ivals,
         n_class=classifier_config.n_class,
-        adaptation=classifier_config.adaptation,
+        do_adaptation=classifier_config.adaptation,
         dynamic_stopping=classifier_config.dynamic_stopping,
         dynamic_stopping_params=classifier_config.dynamic_stopping_params,
         max_n_stims=classifier_config.n_stimulus,

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -210,7 +210,7 @@ def test_acquisition_controller_initiation(
         filter_order=classifier_config.filter_order,
         ivals=classifier_config.ivals,
         n_class=classifier_config.n_class,
-        adaptation=classifier_config.adaptation,
+        do_adaptation=classifier_config.adaptation,
         dynamic_stopping=classifier_config.dynamic_stopping,
         dynamic_stopping_params=classifier_config.dynamic_stopping_params,
         max_n_stims=classifier_config.n_stimulus,


### PR DESCRIPTION
adaptation_clf was not initiated correctly in the acquisition system controller. I fixed this according to how adaptation_clf was assigned in the original python code. I don't quite understand why taking the first index of the classifier object returns the adaptation object, but I'm guessing it's some kind of tuple. Regardless, this fix is in line with the previously functional implementation.